### PR TITLE
#2.1.28 — исправление при отсутствии обложки/логотипа

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -319,18 +319,27 @@
                 const appYa_setting_coverQuality = localStorage.getItem('appYa_setting_coverQuality') ?? '400';
                 let qq = `${appYa_setting_coverQuality}x${appYa_setting_coverQuality}`
 
-                const coverUrl = trackInfo.albums[0].coverUri.replace('%%', qq); // Подставляем размер
-                const artistUrl = trackInfo.artists[0].cover?.uri?.replace('%%', qq); // Подставляем размер
+                const coverUrl = trackInfo.albums[0]?.coverUri?.replace('%%', qq); // Подставляем размер
+                const artistUrl = trackInfo.artists[0]?.cover?.uri?.replace('%%', qq); // Подставляем размер
 
-                const coverResponse = await fetch(`https://${coverUrl}`);
-                const artistcoverResponse = await fetch(`https://${artistUrl}`);
-
-                if (!coverResponse.ok) {
-                    throw new Error(`Ошибка загрузки обложки: ${coverResponse.statusText}`);
+                // Загружаем обложку альбома, только если она есть
+                let coverData = null;
+                if (coverUrl) {
+                    const coverResponse = await fetch(`https://${coverUrl}`);
+                    if (!coverResponse.ok) {
+                        throw new Error(`Ошибка загрузки обложки: ${coverResponse.statusText}`);
+                    }
+                    coverData = new Uint8Array(await coverResponse.arrayBuffer());
                 }
 
-                const coverData = new Uint8Array(await coverResponse.arrayBuffer());
-                const artistcoverResponseData = new Uint8Array(await artistcoverResponse.arrayBuffer());
+                // Загружаем логотип артиста, только если он есть
+                let artistcoverResponseData = null;
+                if (artistUrl) {
+                    const artistcoverResponse = await fetch(`https://${artistUrl}`);
+                    if (artistcoverResponse.ok) {
+                        artistcoverResponseData = new Uint8Array(await artistcoverResponse.arrayBuffer());
+                    }
+                }
 
                 // Обновляем метаданные
                 const writer = new ID3Writer(mp3Data);
@@ -343,19 +352,25 @@
                     .setFrame('TALB', trackInfo.albums[0].title) // Альбом
                     .setFrame('TYER', trackInfo.albums[0].year) // Год выпуска
                     .setFrame('TCON', trackInfo.albums[0]?.genre?.split(',') || ['Unknown']) // Жанр (например, "Pop", "Rock")
-                    .setFrame('TRCK', `${currentTrackNumber}/${totalTracksInAlbum}`) //TPOS (позиция трека в альбоме)
-                    //Обложка альбома (спереди)
-                    .setFrame('APIC', {
+                    .setFrame('TRCK', `${currentTrackNumber}/${totalTracksInAlbum}`); //TPOS (позиция трека в альбоме)
+
+                // Обложка альбома (спереди) — только если загружена
+                if (coverData) {
+                    writer.setFrame('APIC', {
                         type: 3,
                         data: coverData,
                         description: 'Cover (front)'
-                    })// Логотип группы/артиста
-                    .setFrame('APIC', {
+                    });
+                }
+                // Логотип группы/артиста — только если загружен
+                if (artistcoverResponseData) {
+                    writer.setFrame('APIC', {
                         type: 17, // Band/Artist Logotype
                         data: artistcoverResponseData,
                         description: 'Band Logo'
-                    })
-                    .addTag();
+                    });
+                }
+                writer.addTag();
 
                 console.log('appYa_trackInfo_writer', (writer));
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -101,18 +101,23 @@ const uiUpdater = {
 
         workPanel.style.display = 'flex';
         const track = parsedData.appYa_cureitTrack.trackinfo;
-        const imageURL = `https://${track.coverUri.replace(/%%/g, cQR)}`;
+        const coverUri = track.coverUri ?? track.albums?.[0]?.coverUri;
+        const imageURL = coverUri ? `https://${coverUri.replace(/%%/g, cQR)}` : '';
         const artists = track.artists.map((item) => item.name).join(', ');
         const albums = track.albums.map((item) => item.year).join(', ');
 
         document.getElementById('trackName').innerText = track.title;
         document.getElementById('artistsList').innerHTML = `${artists}<br>${albums}`;
-        document.getElementById('trackImage').src = imageURL;
+        if (imageURL) {
+            document.getElementById('trackImage').src = imageURL;
+        }
 
         //section.style.backgroundColor = track.derivedColors.average;
         //section.style.color = track.derivedColors.waveText;
         //playlistPanelMetaDownloadBtn.style.backgroundColor = track.derivedColors.miniPlayer;
-        document.querySelector('#trackPanel').style.backgroundColor = track.derivedColors.accent;
+        if (track.derivedColors?.accent) {
+            document.querySelector('#trackPanel').style.backgroundColor = track.derivedColors.accent;
+        }
 
         document.getElementById('downloadButton').addEventListener('click', () => {
             eventHandlers.downloadTracks(appYa_tabID, [track.id], 'music');

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Yandex Music Fisher mod by vectorserver",
-  "version": "2.1.27",
+  "version": "2.1.28",
   "description": "Скачивание музыки с сервисов Яндекс.Музыка и Яндекс.Радио",
   "icons": {
     "128": "icons/music_by_pancaza.png"

--- a/manifest_Firefox.json
+++ b/manifest_Firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Yandex Music Fisher mod by vectorserver",
-  "version": "2.1.27",
+  "version": "2.1.28",
   "description": "Скачивание музыки с сервисов Яндекс.Музыка и Яндекс.Радио",
   "icons": {
     "128": "icons/music_by_pancaza.png"


### PR DESCRIPTION
## Описание

Исправлено падение при скачивании трека, у которого отсутствует обложка альбома или логотип артиста.

### Изменения
- **js/parser.js** — обложка альбома и логотип артиста загружаются опционально через optional chaining (`?.`); кадры APIC добавляются в ID3-теги только при наличии загруженных данных.
- **js/popup.js** — предпросмотр обложки и фоновый цвет панели применяются только при наличии данных, с запасным `coverUri` из `albums[0]`.
- **manifest.json / manifest_Firefox.json** — версия поднята 2.1.27 → 2.1.28.